### PR TITLE
Updated the vmware-vra gem dependency

### DIFF
--- a/kitchen-vra.gemspec
+++ b/kitchen-vra.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'test-kitchen'
-  spec.add_dependency 'vmware-vra', '~> 2'
+  spec.add_dependency 'vmware-vra', '~> 2', '< 3' # 3.0 and newer is not supported
   spec.add_dependency 'highline'
   spec.add_dependency 'rack', '~> 1.6' unless RUBY_VERSION.index('2.0.').nil?
   spec.add_dependency 'ffi-yajl', '~> 2.2.3' unless RUBY_VERSION.index('2.0.').nil?


### PR DESCRIPTION
Signed-off-by: Ashique Saidalavi <ashique.saidalavi@progress.com>

### Description
After fixing #34, this gem and the dependent vmware-vra gem will bump to the next major version and the current version of this gem is dependent on vmware-vra 2.0 to 2.9. This PR is to update the gem dependency. 

<!--- Describe what this change achieves--->

### Issues Resolved

<!--- List any existing issues this PR resolves--->

### Check List

- [ ] All tests pass.
- [ ] All style checks pass.
- [ ] Functionality includes testing.
- [ ] Functionality has been documented in the README if applicable
