### PR TITLE
Require Ruby 2.7 and later

### DIFF
--- a/kitchen-vra.gemspec
+++ b/kitchen-vra.gemspec
@@ -20,11 +20,13 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = ">= 2.7"
+
   spec.add_dependency 'test-kitchen'
   spec.add_dependency 'vmware-vra', '~> 3.0' # 3.0 required for vRA 8.x
   spec.add_dependency 'highline'
-  spec.add_dependency 'rack', '~> 1.6' unless RUBY_VERSION.index('2.0.').nil?
-  spec.add_dependency 'ffi-yajl', '~> 2.2.3' unless RUBY_VERSION.index('2.0.').nil?
+  spec.add_dependency 'rack', '~> 1.6'
+  spec.add_dependency 'ffi-yajl', '~> 2.2.3'
   spec.add_development_dependency 'bundler', '>= 1.7'
   spec.add_development_dependency 'rake',      '~> 10.0'
   spec.add_development_dependency 'rspec',     '~> 3.2'


### PR DESCRIPTION
We should not be supporting legacy Ruby releases with this major update

Signed-off-by: Tim Smith <tsmith@chef.io>