### PR TITLE
Update username example when prompt ask for username

### DIFF
--- a/lib/kitchen/driver/vra.rb
+++ b/lib/kitchen/driver/vra.rb
@@ -73,7 +73,7 @@ module Kitchen
         config[:password] = config[:password] || ENV["VRA_USER_PASSWORD"]
         c_load if config[:username].nil? && config[:password].nil?
 
-        config[:username] = ask("Enter Username: e.g. username@domain") if config[:username].nil? || force_change
+        config[:username] = ask("Enter Username: e.g. username") if config[:username].nil? || force_change
         config[:password] = ask("Enter password: ") { |q| q.echo = "*" } if config[:password].nil? || force_change
         c_save if config[:cache_credentials]
       end

--- a/lib/kitchen/driver/vra.rb
+++ b/lib/kitchen/driver/vra.rb
@@ -73,7 +73,7 @@ module Kitchen
         config[:password] = config[:password] || ENV["VRA_USER_PASSWORD"]
         c_load if config[:username].nil? && config[:password].nil?
 
-        config[:username] = ask("Enter Username: e.g. username") if config[:username].nil? || force_change
+        config[:username] = ask("Enter Username: e.g. johnsmith") if config[:username].nil? || force_change
         config[:password] = ask("Enter password: ") { |q| q.echo = "*" } if config[:password].nil? || force_change
         c_save if config[:cache_credentials]
       end


### PR DESCRIPTION
# Description
Update username example when the prompt asks for a username. 
Current behavior includes the domain name as an example which is not valid

## Issues Resolved

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [x] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
