### PR TITLE
Replaced the tenant attribute with the domain attribute.

### DIFF
--- a/kitchen-vra.gemspec
+++ b/kitchen-vra.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.7"
 
   spec.add_dependency "test-kitchen"
-  spec.add_dependency "vmware-vra", ">= 3.1.0" # 3.0 required for vRA 8.x
+  spec.add_dependency "vmware-vra", "~> 3.0", ">= 3.2.0" # 3.0 required for vRA 8.x
   spec.add_dependency "highline"
   spec.add_dependency "rack", ">= 1.6", "< 3.0"
   spec.add_dependency "ffi-yajl", ">= 2.2.3", "< 2.5.0"

--- a/lib/kitchen/driver/vra.rb
+++ b/lib/kitchen/driver/vra.rb
@@ -66,8 +66,8 @@ module Kitchen
       default_config :dns_suffix, nil
 
       deprecate_config_for :tenant, Util.outdent!("
-        In vRA8.x, the 'tenant' configuration is no longer required for the authentication,
-        instead, please make advantage of the domain configuration.".dup)
+        In vRA 8.x, the 'tenant' configuration is no longer relevant for authentication.
+        Please use the 'domain' configuration in its place.".dup)
 
       def name
         "vRA"

--- a/lib/kitchen/driver/vra.rb
+++ b/lib/kitchen/driver/vra.rb
@@ -35,11 +35,12 @@ module Kitchen
       default_config :username, nil
       default_config :password, nil
       required_config :base_url
-      required_config :tenant
+      required_config :domain
       required_config :project_id
       required_config :image_mapping
       required_config :flavor_mapping
 
+      default_config :tenant, nil
       default_config :version, nil
       default_config :catalog_id, nil
       default_config :catalog_name, nil
@@ -63,6 +64,10 @@ module Kitchen
       end
       default_config :use_dns, false
       default_config :dns_suffix, nil
+
+      deprecate_config_for :tenant, Util.outdent!("
+        In vRA8.x, the 'tenant' configuration is no longer required for the authentication,
+        instead, please make advantage of the domain configuration.".dup)
 
       def name
         "vRA"
@@ -257,7 +262,7 @@ module Kitchen
           base_url:   config[:base_url],
           username:   config[:username],
           password:   config[:password],
-          tenant:     config[:tenant],
+          domain:     config[:domain],
           verify_ssl: config[:verify_ssl]
         )
       rescue => _e

--- a/spec/vra_spec.rb
+++ b/spec/vra_spec.rb
@@ -36,7 +36,7 @@ describe Kitchen::Driver::Vra do
       base_url:        "https://vra.corp.local",
       username:        "myuser",
       password:        "mypassword",
-      tenant:          "mytenant",
+      domain:          "mytenant.corp.com",
       project_id:      "6ba69375-79d5-42c3-a099-7d32739f71a7",
       image_mapping:   "VRA-nc-lnx-ce8.4-Docker",
       flavor_mapping:  "Small",
@@ -415,7 +415,7 @@ describe Kitchen::Driver::Vra do
           base_url:        "https://vra.corp.local",
           username:        "myuser",
           password:        "mypassword",
-          tenant:          "mytenant",
+          domain:          "domain.corp.com",
           verify_ssl:      true,
           project_id:      "6ba69375-79d5-42c3-a099-7d32739f71a7",
           image_mapping:   "VRA-nc-lnx-ce8.4-Docker",
@@ -435,7 +435,7 @@ describe Kitchen::Driver::Vra do
           base_url:         "https://vra.corp.local",
           username:         "myuser",
           password:         "mypassword",
-          tenant:           "mytenant",
+          domain:           "mydomain.corp.com",
           verify_ssl:       true,
           project_id:       "6ba69375-79d5-42c3-a099-7d32739f71a7",
           image_mapping:    "VRA-nc-lnx-ce8.4-Docker",
@@ -458,7 +458,7 @@ describe Kitchen::Driver::Vra do
       expect(Vra::Client).to receive(:new).with(base_url:   config[:base_url],
                                                 username:   config[:username],
                                                 password:   config[:password],
-                                                tenant:     config[:tenant],
+                                                domain:     config[:domain],
                                                 verify_ssl: config[:verify_ssl])
       driver.vra_client
     end


### PR DESCRIPTION
Signed-off-by: Ashique P S <Ashique.saidalavi@progress.com>

# Description

vRA8 requires the domain attribute set when creating the VM, instead of the older tenant attribute. Today, the kitchen-vra gem passes the domain via the tenant attribute in the kitchen.yml file. This confuses users. This PR is to introduce a domain attribute (mark it required) and deprecate the existing tenant attribute.

The user needs to define the domain rather than the tenant in the kitchen.yml file when using the `kitchen-vra` plugin on the vRA8 setup.

The API Wrapper gem(vmware-vra) is updated with the same [attribute change](https://github.com/test-kitchen/vmware-vra-gem/pull/102) and a new version `3.2.0` is released. Updated the dependency of this gem to install `vmware-vra >= 3.2.0`. 

## Issues Resolved

List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
