### PR TITLE
Fixed the issue with catalog lookup with catalog_name

### DIFF
--- a/spec/vra_spec.rb
+++ b/spec/vra_spec.rb
@@ -41,9 +41,9 @@ describe Kitchen::Driver::Vra do
       image_mapping:   "VRA-nc-lnx-ce8.4-Docker",
       flavor_mapping:  "Small",
       verify_ssl:      true,
-      subtenant_id:    "160b473a-0ec9-473d-8156-28dd96c0b6b7",
       use_dns:         false,
       deployment_name: "test-instance",
+      catalog_id:      "1536b95d-68fe-3c68-9417-46ed24bee3ef",
     }
   end
 
@@ -399,7 +399,7 @@ describe Kitchen::Driver::Vra do
       allow(driver).to receive(:vra_client).and_return(vra_client)
       allow(vra_client).to receive(:catalog).and_return(catalog)
       allow(catalog).to receive(:request).and_return(catalog_request)
-      %i{subtenant_id= set_parameter}.each do |method|
+      %i{catalog_id= set_parameter}.each do |method|
         allow(catalog_request).to receive(method)
       end
     end
@@ -420,11 +420,12 @@ describe Kitchen::Driver::Vra do
           project_id:      "6ba69375-79d5-42c3-a099-7d32739f71a7",
           image_mapping:   "VRA-nc-lnx-ce8.4-Docker",
           flavor_mapping:  "Small",
+          catalog_id:      "2kabc423-af89-56fc-990a-82fab34ed12",
         }
       end
 
       it "does not attempt to set params on the catalog_request" do
-        expect(catalog_request).not_to receive(:subtenant_id=)
+        expect(catalog_request).not_to receive(:set_parameters)
         driver.catalog_request
       end
     end
@@ -440,6 +441,7 @@ describe Kitchen::Driver::Vra do
           project_id:       "6ba69375-79d5-42c3-a099-7d32739f71a7",
           image_mapping:    "VRA-nc-lnx-ce8.4-Docker",
           flavor_mapping:   "Small",
+          catalog_id:      "2kabc423-af89-56fc-990a-82fab34ed12",
           extra_parameters: { "key1" => { type: "string", value: "value1" },
                               "key2" => { type: "integer", value: 123 } },
         }


### PR DESCRIPTION
Signed-off-by: Ashique P S <Ashique.saidalavi@progress.com>

# Description

The `catalog_name` configuration was used to pass a catalog name and the driver will automatically fetch the catalog_id from the vRA server. There are some issues with parsing the response and I've added a fix for that. 

Additionally, in vRA 8.X, the concept of subtenants is removed. Hence removing the obsolete configuration and its code. 

## Issues Resolved

List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
